### PR TITLE
Add name to CI lint-and-test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: Continuous Integration
 on:
   pull_request:
+  push:
 jobs:
   lint-and-test:
+    name: "Lint and Test"
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Continuous Integration
 on:
   pull_request:
-  push:
 jobs:
   lint-and-test:
     name: "Lint and Test"


### PR DESCRIPTION
## Summary
Add a name for the CI lint-and-test step so we can use it in the github status checks.