### PR TITLE
Add actions for releasing new versions to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+# This workflow will run tests using node and then publish a package to npm
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Publish to npm
+
+on: [workflow_dispatch, workflow_call]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches: [master]
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      did-create-release: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: \@circle-fin/contract-cli
+
+  npm-publish:
+    needs: release-please
+    if: needs.release-please.outputs.did-create-release
+    uses: ./.github/workflows/npm-publish.yml
+    secrets: inherit

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -87,15 +87,15 @@ export default class Execute extends Command {
     ]);
 
     result.stdout.on("data", (data) => {
-      this.log(`contract-cli: ${data}`);
+      this.log(`contract-cli: ${data.toString().trim()}`);
     });
 
     result.stderr.on("data", (data) => {
-      this.logToStderr(`contract-cli: ${data}`);
+      this.logToStderr(`contract-cli: ${data.toString().trim()}`);
     });
 
     result.on("error", (error) => {
-      this.logToStderr(`contract-cli: ${error.message}`);
+      this.logToStderr(`contract-cli: ${error.message.toString().trim()}`);
     });
 
     result.on("close", () => {


### PR DESCRIPTION
## Summary
Add workflows for release-please and NPM Publishing.

## Detail
- Release-please uses semantic versioning to auto-create PRs containing the correct version bumps
- Once release-please PRs are merged, the publish action is triggered to publish the updated version to NPM

## Documentation
- Release-please: https://github.com/google-github-actions/release-please-action
