### PR TITLE
ci: update actions to use node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,8 +9,8 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
Node 16 is EOL, upgrade action versions to use node 20

## Release Notes
* actions/checkout v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
* actions/setup-node v3 -> v4: https://github.com/actions/setup-node/releases/tag/v4.0.0